### PR TITLE
Undefined key on checkConnect function

### DIFF
--- a/app/controllers/UsersController.php
+++ b/app/controllers/UsersController.php
@@ -58,7 +58,7 @@ class UsersController extends Controller {
 
 	public function checkConnectedAction(){
 		if($this->session->has("token")){
-			echo '{"token" : "'.$this->session->get("token").'",connected: true}';
+			echo '{"token" : "'.$this->session->get("token").'","connected": true}';
 		}else{
 			echo '{"connected": false}';
 		}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| Deprecations? | no |
| Tests pass? | yes |

There were no commas around the "connected" key on the JSON response of the checkConnectionAction method.

Result expected : connected: true
Result found : undefined: true
